### PR TITLE
Cleanup command line options and make receivers configurable

### DIFF
--- a/simple-streaming-app/build.sbt
+++ b/simple-streaming-app/build.sbt
@@ -7,6 +7,7 @@ lazy val root = (project in file(".")).
     resolvers += "bintray-typesafe-maven-releases" at "http://dl.bintray.com/typesafe/maven-releases",
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-core" % "1.4.0",
-      "org.apache.spark" %% "spark-streaming" % "1.4.0"
+      "org.apache.spark" %% "spark-streaming" % "1.4.0",
+      "com.github.scopt" %% "scopt" % "3.3.0"
     )
   )

--- a/simple-streaming-app/src/main/scala/com/typesafe/spark/Config.scala
+++ b/simple-streaming-app/src/main/scala/com/typesafe/spark/Config.scala
@@ -1,0 +1,10 @@
+package com.typesafe.spark
+
+case class Config(
+    master: String,
+    hostname: String,
+    port: Int,
+    batchInterval: Int,
+    strategy: String,
+    streams: Int,
+    step: Int)

--- a/simple-streaming-app/src/main/scala/com/typesafe/spark/SimpleStreamingApp.scala
+++ b/simple-streaming-app/src/main/scala/com/typesafe/spark/SimpleStreamingApp.scala
@@ -6,7 +6,6 @@ import org.apache.spark.streaming.Milliseconds
 import scala.util.Try
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.io
 import com.typesafe.spark.test.Hanoi
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.DStream
@@ -31,8 +30,10 @@ object SimpleStreamingApp {
     }
     val conf = new SparkConf()
       .setAppName("Streaming tower of Hanoi resolution")
-      .setMaster(config.master)
       .set("spark.streaming.receiver.congestionStrategy", config.strategy)
+
+     if (conf.getOption("spark.master").isEmpty)
+       conf.setMaster(config.master)
 
     val ssc = new StreamingContext(conf, Milliseconds(config.batchInterval))
 

--- a/simple-streaming-app/src/main/scala/com/typesafe/spark/SimpleStreamingApp.scala
+++ b/simple-streaming-app/src/main/scala/com/typesafe/spark/SimpleStreamingApp.scala
@@ -27,7 +27,11 @@ object SimpleStreamingApp {
 
     val ssc = new StreamingContext(conf, Milliseconds(batchInterval))
 
-    val lines = ssc.socketTextStream(hostname, port, StorageLevel.MEMORY_ONLY)
+    val rawInput1 = ssc.socketTextStream(hostname, port, StorageLevel.MEMORY_ONLY)
+    val rawInput2 = ssc.socketTextStream(hostname, port, StorageLevel.MEMORY_ONLY).flatMap(x => Seq(x, x))
+
+    // test two different receivers, one with twice as many elements as the other
+    val lines = rawInput1.union(rawInput2)
 
     val numbers = lines.flatMap { line => Try(Integer.parseInt(line)).toOption }
 


### PR DESCRIPTION
The second stream has twice as many elements as the first (though they come from the same producer).
