### PR TITLE
Adds support to avoid write exception on tcp

### DIFF
--- a/testbed/app/com/typesafe/spark/testbed/SerFurAct.scala
+++ b/testbed/app/com/typesafe/spark/testbed/SerFurAct.scala
@@ -76,7 +76,7 @@ class Connection(socket: AsynchronousSocketChannel, connectionHandler: ActorRef)
           socket.close()
           connectionHandler ! Server.ConnectionClosedMsg
         } else {
-          // do do anything on incoming bytes, just wait for the end of the stream
+          // don't do anything on incoming bytes, just wait for the end of the stream
         	process()
         }
     }

--- a/testbed/build.sbt
+++ b/testbed/build.sbt
@@ -1,24 +1,9 @@
-//name := "spark-streaming-testbed"
-
-//version := "0.1"
-
-//lazy val root = (project in file(".")).enablePlugins(PlayScala)
-
-//scalaVersion := "2.11.1"
-
-//libraryDependencies ++= Seq(
-//  jdbc,
-//  anorm,
-//  cache,
-//  ws
-//)
-
 lazy val root = (project in file(".")).
   enablePlugins(PlayScala).
   settings(
     organization := "com.typesafe.spark",
     name := "spark-streaming-testbed",
-    version := "0.1",
+    version := "0.1.1",
     scalaVersion := "2.10.5",
     libraryDependencies ++= Seq(
       jdbc,


### PR DESCRIPTION
Java NIO 2 throws an exception when trying to write
to a socket when the previous write was not 'completed'.
Now listen to the feedback that a write has been completed, and guard
to send message if the socket is not ready yet.
Log the problem when it appears.
